### PR TITLE
Intro to git

### DIFF
--- a/Introduction to Git/includes/05-fix-simple-mistakes.md
+++ b/Introduction to Git/includes/05-fix-simple-mistakes.md
@@ -67,8 +67,13 @@ On branch master
 nothing to commit, working tree clean
 ```
 
-You can also check out a file from an earlier commit, or even from another
-branch, but the default is to get the file out of the index.
+You can also check out a file from another commit (typically the head of
+another branch), but the default is to get the file out of the index.  The
+`--` in the argument list is there to separate the commit from the list of
+file paths.  It's not strictly needed in this case, but if there had been a
+branch called `index.html` (perhaps because that's the name of the file being
+worked on on that branch) or a file called `master`, it would be needed to
+resolve the ambiguity.
 
 Things are a little more complicated if you used `git rm`:
 
@@ -117,9 +122,11 @@ back, make the change correctly, and `git commit --amend`.  Or you could use
 change and the commit.
 
 But suppose you didn't notice the problem until you'd already made another
-commit after the bad one, or published the commit on a shared repo. 
-<!-- FIXME: make sure unit ref is correct -->
-Another way is to _revert_ the change:
+commit after the bad one, shared your repo with a coworker (see the next unit)
+or made the commit public (see Unit 7).  Changing history can be dangerous
+(see almost any science fiction story about time travel).  It this situation,
+the best thing to do is to _revert_ the change, by making another commit that
+cancels out the first one:
 
 ```
 $ git revert --no-edit HEAD 

--- a/Introduction to Git/includes/06-collaborate-using-pull.md
+++ b/Introduction to Git/includes/06-collaborate-using-pull.md
@@ -1,37 +1,218 @@
-# Collaborate using pull
+# Collaborate using Pull
 
-As work on the website progresses one of your coworkers, Alice, offers to help
-you write some of the content.  She will need to make a copy of your project,
+As work on the website progresses one of your coworkers, <a
+href="https://en.wikipedia.org/wiki/Alice_and_Bob" >Alice</a>, offers to help
+you write the CSS stylesheet.  She will need to make a copy of your project,
 and send her changes to you as she makes them.  This is where `git`'s
 _distributed_ nature comes in.
 
-## Alice clones your project
+## Cloning a repository
 
 Instead of making an empty directory and running `git init` to initialize it,
-Alice uses `git clone` copy your repo.  In this section, we'll use a directory
-to hold Alice's copy of the `Website` project.  You're probably in the Website
-project directory, so you'll want to change to the parent directory first.
+Alice uses `git clone` to copy your repo.  In this section, we'll use a
+directory to hold Alice's copy of the `Website` project.  You're probably in
+the Website project directory, so you'll want to change to the parent
+directory first.
 
-```
+```bash
 $ cd ..
 $ mkdir Alice
 $ cd Alice
 $ git clone ../Website
+Cloning into 'Website'...
+done.
 $ cd Website
 ```
 
-Alice will need to configure Git with her name and email address.  Since she's
-working using your account (which is very bad from a security point of view,
-but she can get away with it because she doesn't really exist) she will have
-to use local configuration variables for this:
+Usually `git clone` takes a URL (the various types are described in the
+[documentation](https://git-scm.com/docs/git-clone)) that points to the
+repository being cloned, but it can also use a file system path if the
+repository is local; that's what Alice has done here.  On Unix and Linux, the
+cloning operation uses hard links, which is fast and takes up very little
+space because only the directory entries need to be copied, not the files.
 
-```
+Because Alice is working using your account (which is very bad from a security
+point of view, but she can get away with it because she doesn't really exist)
+she has to use local configuration variables:
+
+```bash
 $ git config user.name Alice
 $ git config user.email alice@example.com
 ```
 
-* commit some changes in Alice's directory.
-* pull from Alice. `git pull ../Alice`
-* Make changes in both your tree and Alice's.
-* Alice: `git pull` -- she has an origin remote; you don't.
-  alice blue: 	#F0F8FF body { background-color:  #F0F8FF; } 
+## Remote repositories
+
+When Git clones a repository, it creates a reference to it called a "remote",
+with the name "origin", and sets it up so that it will push and pull from the
+remote repository.
+
+
+```bash
+$ git remote 
+origin
+$ git branch -a
+* master
+  remotes/origin/HEAD -> origin/master
+  remotes/origin/master
+```
+
+Origin is the default location for git to pull changes from and push changes
+to.  In this case, you haven't done anything new, so there's nothing for Alice
+to pull.
+
+```
+$ git pull
+Already up to date.
+```
+
+## Make a change and request a pull
+
+Alice decides to start by changing the site's background color to her favorite
+shade of light blue, and committing the change:
+
+```bash
+$ sed -i.bak -E '/background-color/s/#.+;/#F0F8FF;/' assets/site.css
+$ git commit -a -m "change background color to light blue"
+[master 565748d] change background color to light blue
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+$  git status
+On branch master
+Your branch is ahead of 'origin/master' by 1 commit.
+  (use "git push" to publish your local commits)
+
+nothing to commit, working tree clean
+```
+
+Now she has to get the changes over to _your_ copy of the project.  Since Git
+suggests using `git push`, she tries that first:
+
+```bash
+$  git push
+Counting objects: 4, done.
+Delta compression using up to 2 threads.
+Compressing objects: 100% (3/3), done.
+Writing objects: 100% (4/4), 403 bytes | 403.00 KiB/s, done.
+Total 4 (delta 1), reused 0 (delta 0)
+remote: error: refusing to update checked out branch: refs/heads/master
+remote: error: By default, updating the current branch in a non-bare repository
+remote: is denied, because it will make the index and work tree inconsistent
+remote: with what you pushed, and will require 'git reset --hard' to match
+remote: the work tree to HEAD.
+remote: 
+remote: You can set the 'receive.denyCurrentBranch' configuration variable
+remote: to 'ignore' or 'warn' in the remote repository to allow pushing into
+remote: its current branch; however, this is not recommended unless you
+remote: arranged to update its work tree to match what you pushed in some
+remote: other way.
+remote: 
+remote: To squelch this message and still keep the default behaviour, set
+remote: 'receive.denyCurrentBranch' configuration variable to 'refuse'.
+To /home/steve/vv/prj/ms-learn/sandbox/Alice/../Website
+ ! [remote rejected] master -> master (branch is currently checked out)
+error: failed to push some refs to '/home/steve/vv/prj/ms-learn/sandbox/Alice/../Website'
+```
+
+Well, _that_ didn't work.  (It's worth noting that if Alice didn't have write
+permission for your repository, the error message would have included "fatal:
+Could not read from remote repository" -- see the next section for an
+example.)  We'll see in the next unit how to set up a _shared_ repository that
+both of you can push to, but for now Alice is going to have to ask you to
+_pull_ her changes.  She can do that by running `git request-pull` and
+emailing you the output:
+
+```
+$ git request-pull -p origin/master ../../Alice/Website
+The following changes since commit a898ec56cf7f591cfa11a82d50b433e655572e75:
+
+  make the page background a little darker (2019-03-24 08:07:47 -0700)
+
+are available in the Git repository at:
+
+  ../../Alice/Website
+
+for you to fetch changes up to 565748d7955e6c9cf7e5829ac933dcc60627dbca:
+
+  change background color to light blue (2019-03-29 08:42:23 -0700)
+
+----------------------------------------------------------------
+Alice (1):
+      change background color to light blue
+
+ assets/site.css | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+ 
+diff --git a/assets/site.css b/assets/site.css
+index cd827ec..aa55481 100644
+--- a/assets/site.css
++++ b/assets/site.css
+@@ -1,2 +1,2 @@
+ h1, h2, h3, h4, h5, h6 { font-family: sans-serif; }
+-body { background-color:  #F0F0F0; }
++body { background-color:  #F0F8FF; }
+
+```
+
+A few things to notice:  `origin/master` is Alice's way of referring to the
+`master` branch on the `origin` remote.  The path `../../Alice/Website` would
+normally be relative to Alice's home directory or, better, the URL of a public
+repository that Alice can push to (we'll see how to set that up in the next
+unit) and you can pull from.
+
+This pull request is essentially the same thing as a pull request on
+[GitHub](https://github.com).  In addition to asking you to pull Alice's
+changes, it is also asking you to _review_ those changes first.  Code reviews
+are an important part of collaborative programming.
+
+## An unsuccessful pull
+
+Now, you can try to pull from Alice's repository:
+
+```
+$ cd ../../Website
+$ git pull ../../Alice/Website
+fatal: '../../Alice/Website' does not appear to be a git repository
+fatal: Could not read from remote repository.
+
+Please make sure you have the correct access rights
+and the repository exists.
+```
+
+That didn't work because the path you took out of Alice's email was relative
+to _her_ repository, not yours.  An absolute path or a public URL would have
+worked in this case, but since you and Alice are going to be collaborating
+more often it makes more sense to create a remote.
+
+## Create a remote and pull from it
+
+You create a remote using 
+
+```
+$ git remote add alice ../Alice/Website
+$ git pull alice master
+From ../Alice/Website
+ * branch            HEAD       -> FETCH_HEAD
+Updating a898ec5..565748d
+Fast-forward
+ assets/site.css | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+```
+
+Notice that you had to specify a branch.  We'll see in the next unit how to
+fix that.
+
+Behind the scenes, `git pull` is a combination of two simpler operations:
+`git fetch`, which gets the changes, and `git merge`, which merges those
+changes into your repository.  In this case, the merge was "fast-forward",
+meaning that Alice had your latest commit in her repository, so her commit
+could be added to the front of your history without any modification.
+
+There's only one catch: this only works if Alice can access your computer, and
+vice versa.  That's almost never true.
+
+## Commands in this unit
+
+* `git clone`
+* `git pull`
+* `git push`
+* `git branch`
+* `git remote`

--- a/Introduction to Git/includes/07-collaborate-using-a-shared-repo.md
+++ b/Introduction to Git/includes/07-collaborate-using-a-shared-repo.md
@@ -1,20 +1,217 @@
 # Collaborate using a shared repo
 
-When Bob decides to join the project as well, you realize that it would help
-if there was an "official" copy of the project that you can all share.  This
-will also come in handy when the website goes live, because the server will be
-able to pull from it too.
+Directly pulling from someone else's repository works, provided you're both on
+the same network, but it's clumsy.  It's much better to set up a central
+repository that you can both push to as well as pull from.  When Bob decides
+to join the project as well, that's exactly what you do.
 
-* `git clone --bare project project.git`
-* `git clone project.git Bob` (briefly mention ssh at this point; we don't
-  need that complication right now, but we'll be using it in the next module.)
-* You and Alice want to be able to pull from the shared repo instead of from
-  each other.  Alice's repo already has an origin, so she can use
-  `git remote --set-url origin ../project.git`
-* It's a little more complicated for you. `git remote origin ../project.git`
-  When you try to push, git asks which branch.  reply with "master"
-  You eliminate that question for future uploads with
-  `git branch --set-upstream-to origin` -- doesn't work before the
-  master branch is actually pushed.
-* pull before push.  (Alice and Bob both make changes.  Alice pushes first,
-  so Bob has to `git pull --rebase; git push`  (more about rebase later)
+## Set up a bare repository
+
+What you need is a repository that doesn't have a working tree, to avoid the
+problem Alice had trying to push.  That's called a "bare repository", and you
+can set it up using:
+
+```
+$ cd ..
+$ mkdir Website.git
+$ cd Website.git
+$ git init --bare
+Initialized empty Git repository in .../sandbox/Website.git/
+```
+
+(The convention for bare repositories is to give them a name ending with
+`.git` to distinguish them from working trees.)
+
+Now you have to get the contents of _your_ repo into the new one.  You set up
+an `origin` remote and push to it.
+
+```
+$ cd ../Website
+$ git remote add origin ../Website.git
+$ git push origin master
+Counting objects: 40, done.
+Delta compression using up to 2 threads.
+Compressing objects: 100% (28/28), done.
+Writing objects: 100% (40/40), 3.80 KiB | 432.00 KiB/s, done.
+Total 40 (delta 6), reused 0 (delta 0)
+To ../Website.git
+ * [new branch]      master -> master
+```
+
+Since you want push and pull to use `origin`'s master branch by default, the
+way they do in a cloned repository, you need to tell Git which branch to
+track:
+
+```
+$ git branch --set-upstream-to origin/master
+Branch 'master' set up to track remote branch 'master' from 'origin'.
+```
+
+Git would have complained if you had tried to do this before the initial push,
+because there weren't any branches in the new repository yet and Git won't let
+you track a branch that doesn't exist.
+
+## Setup for collaborators
+
+Now all Bob has to do is clone the bare repository:
+
+```
+$ mkdir Bob
+$ cd Bob
+$ git clone ../Website.git/
+Cloning into 'Website'...
+done.
+$ cd Website
+$ git config user.name Bob
+$ git config user.email bob@example.com
+```
+
+Alice already has a remote called `origin`, so all she has to do is change
+which repo it's pointing to:
+
+```
+$ cd ../../Alice/Website
+$ git remote set-url origin ../../Website.git
+$ git push
+Everything up-to-date
+```
+
+## The basics of collaboration
+
+Bob decides to change the page's title, currently "Sample Page", to match the
+`h1` tag:
+
+```
+$ cd ../../Bob/Website
+$ sed -i.bak -e 's/Sample page/Hello, everybody!/' index.html
+$ git commit -a -m "make page title match heading"
+$ git push
+Counting objects: 3, done.
+Delta compression using up to 2 threads.
+Compressing objects: 100% (3/3), done.
+Writing objects: 100% (3/3), 284 bytes | 284.00 KiB/s, done.
+Total 3 (delta 2), reused 0 (delta 0)
+To /home/steve/vv/prj/ms-learn/sandbox/Bob/../Website.git/
+   565748d..8af5fea  master -> master
+```
+
+He sends email to the rest of his team to let them know that he's made a
+change.
+
+Meanwhile, Alice decides to add a nav bar to the page, and adds a line to the
+style sheet for it as well.
+
+```
+$ cd ../../Alice/Website
+$ sed -i.bak -e '/<body>/a<nav> <a href="./">home<\/a> <\/nav>' index.html
+$ echo 'nav { background-color: #C0D8DF; }' >> assets/site.css
+```
+
+Then she sees Bob's email, and decides to pull his changes before she commits
+her own.  (If she had already committed her change, she would have a different
+problem, which we'll discuss in the next unit.)
+
+```
+$ git pull
+Updating 565748d..8af5fea
+error: Your local changes to the following files would be overwritten by merge:
+	index.html
+Please commit your changes or stash them before you merge.
+Aborting
+```
+
+It looks as though Git has prevented a problem.  Note that only `index.html`
+would have been overwritten; Bob didn't make any changes in `site.css`.  Alice
+uses `git diff` to see what Bob's changes were.
+
+```
+$  git diff origin -- index.html
+diff --git a/index.html b/index.html
+index a02a169..7692b01 100644
+--- a/index.html
++++ b/index.html
+@@ -2,10 +2,11 @@
+ <html>
+ <head>
+ <meta charset='UTF-8'>
+-<title>Hello, everybody!</title>
++<title>Sample page</title>
+ <link rel="stylesheet" href="assets/site.css">
+ </head>
+ <body>
++<nav> <a href="./">home</a> </nav>
+ <h1>Hello, everybody!</h1>
+ <p> If this were a real website there would be content here.
+ <hr>
+```
+
+She can see that, although she and Bob have both changed the same file, their
+changes don't overlap.  She decides to stash her changes; `git stash` saves
+the state of the working tree and index by making a couple of temporary
+commits.  (She should have stashed or committed her changes _before_ trying to
+pull.  Pulling to a "dirty" working tree is risky, because it can do things
+you can't recover from.)
+
+```
+$ git stash
+Saved working directory and index state WIP on master: 565748d change
+background color to light blue
+```
+
+Now it's safe for Alice to pull, after which she can "pop" the stash, which is
+organized as a stack.  (In fact, `git stash` is shorthand for `git stash
+push`.) 
+
+```
+$ git pull
+Updating 565748d..8af5fea
+Fast-forward
+ index.html | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+$ git stash pop
+Auto-merging index.html
+On branch master
+Your branch is up to date with 'origin/master'.
+
+Changes not staged for commit:
+  (use "git add <file>..." to update what will be committed)
+  (use "git checkout -- <file>..." to discard changes in working directory)
+
+	modified:   assets/site.css
+	modified:   index.html
+
+no changes added to commit (use "git add" and/or "git commit -a")
+Dropped refs/stash@{0} (440daeff1849a5f6216fbb6960bfe63d8505a67d)
+```
+
+Popping the stash merges the changes; if changes overlap there may be a
+conflict, which we will look at later.
+
+At this point Alice can continue working, or commit and push her changes.
+
+```
+$ git commit -a -m 'add nav bar to page'
+[master 33b6bc7] add nav bar to page
+ 2 files changed, 2 insertions(+)
+$ git push
+Counting objects: 5, done.
+Delta compression using up to 2 threads.
+Compressing objects: 100% (4/4), done.
+Writing objects: 100% (5/5), 486 bytes | 486.00 KiB/s, done.
+Total 5 (delta 2), reused 0 (delta 0)
+To ../../Website.git
+   8af5fea..33b6bc7  master -> master
+```
+
+If Alice had committed her changes rather than stashing them, the situation
+would have been somewhat different -- she would have had to make a branch and
+either merge or rebase her changes.  If she'd been working on a branch in the
+first place she would have saved herself quite a lot of trouble.  We'll see
+how to do that in the next unit; for now it's worth pointing out that
+branching and rebasing is _exactly_ what the stash commands accomplish behind
+the scenes.
+
+## Commands in this unit
+
+* `git push`
+* `git stash`

--- a/Introduction to Git/includes/08-branching-and-merging.md
+++ b/Introduction to Git/includes/08-branching-and-merging.md
@@ -1,8 +1,52 @@
-# Branching and merging
+# Branch, merge, and rebase
 
 At this point it's become clear that you need a way for people to work more
-independently.  Branches make this easy, and unlike many other
-version control systems, making a branch in `git` is nearly instantaneous.
+independently.  Branches make this easy -- work "on a branch" doesn't have to
+be shared.
+
+## Introduction to branches
+
+A branch is simply a chain of commits "branching off" from the main line of
+development like a branch on a tree.  (Some version control systems,
+Subversion for example, actually call their main branch "trunk"; Git calls it
+`master`.  You can rename `master`, just as you can rename any other branch,
+and some teams do this when switching to Git from some other version control
+system.)
+
+Initially a branch starts with a commit on `master` and grows a separate
+history chain as commits are added to it; eventually it can have its changes
+merged back into `master` (we'll see two different ways of doing that --
+merging and rebasing -- later on in this unit).
+
+## Work on a branch
+
+Alice decides to do some more work on the style sheet, so she starts a new
+"topic branch" (sometimes called a "feature branch") called `style`:
+
+```
+$ git branch style
+$  git checkout style
+Switched to branch 'style'
+```
+
+The `git branch` command creates the branch, starting with the current HEAD.
+The `git checkout` command switches to the new branch.  We've already
+encountered `checkout` as a way of replacing files in the working tree by
+getting it from the index.  You can also specify a commit to take the files
+from, in which case both the index and the working tree will be updated.  With
+no paths at the end of the argument list, `checkout` updates _everything_ in
+the working tree and the index from the specified commit, in this case the
+head of the branch.
+
+You can combine creating a branch and switching to it by passing the `-b`
+option to `checkout`.  That's by far the most common way of creating a branch.
+
+Now that Alice is working on a private branch, she's free to make changes
+without interfering with anyone else's work.
+
+```
+
+```
 
 * discuss feature branches.
 * git branch


### PR DESCRIPTION
Here's a pull request for a second set of changes to Intro to Git.

Git made this easy:

```
 git subtree split -P Learn_to_Use_Git -b intro-to-git --rejoin
```
and in my clone of MSLearn, 

```
 git subtree pull -P Introduction\ to\ Git ssavitzky intro-to-git
 push origin intro-to-git
```
It'll be just as easy going in the opposite direction after edits.